### PR TITLE
update spark operator helm chart version

### DIFF
--- a/add-ons/spark-operator/Chart.yaml
+++ b/add-ons/spark-operator/Chart.yaml
@@ -8,13 +8,13 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: "1.0"
 
 dependencies:
-- name: spark-operator
-  version: 1.1.6
-  repository: https://googlecloudplatform.github.io/spark-on-k8s-operator
+  - name: spark-operator
+    version: 1.1.15
+    repository: https://googlecloudplatform.github.io/spark-on-k8s-operator


### PR DESCRIPTION
*Description of changes:*
Updates the helm chart for the Spark on Kubernetes Operator from version 1.1.6 to 1.1.15

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
