### PR TITLE
Update karpenter helm chart to 0.6.3

### DIFF
--- a/add-ons/karpenter/Chart.yaml
+++ b/add-ons/karpenter/Chart.yaml
@@ -8,7 +8,7 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # Version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -16,5 +16,5 @@ appVersion: "1.0"
 
 dependencies:
 - name: Karpenter
-  version: 0.5.6
+  version: 0.6.3
   repository: https://charts.karpenter.sh

--- a/add-ons/karpenter/values.yaml
+++ b/add-ons/karpenter/values.yaml
@@ -2,10 +2,9 @@ karpenter:
   serviceAccount:
     create: false
     name: ""
-  controller:
-    clusterName: ""
-    clusterEndpoint: ""
-    nodeSelector:
-      kubernetes.io/os: linux
+  nodeSelector:
+    kubernetes.io/os: linux
+  clusterName: ""
+  clusterEndpoint: ""
   aws:
     defaultInstanceProfile: ""


### PR DESCRIPTION
*Description of changes:*

Updates the helm chart for Karpenter to 0.6.3. The `values.yaml` structure changed between versions, which I updated and tested as well. New values file in the Karpenter repo: https://github.com/aws/karpenter/blob/v0.6.3/charts/karpenter/values.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
