### PR TITLE
fix: remove incubator reference for yunikorn

### DIFF
--- a/add-ons/yunikorn/Chart.yaml
+++ b/add-ons/yunikorn/Chart.yaml
@@ -17,4 +17,4 @@ appVersion: "1.0"
 dependencies:
   - name: yunikorn
     version: 0.12.2
-    repository: https://apache.github.io/incubator-yunikorn-release
+    repository: https://apache.github.io/yunikorn-release


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-samples/aws-eks-accelerator-for-terraform/issues/368
*Description of changes:*
- Remove incubator reference for yunikorn 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
